### PR TITLE
Fix to include/exclude FK constraint in CREATE TABLE statement 

### DIFF
--- a/sqlglot/dialects/nuodb.py
+++ b/sqlglot/dialects/nuodb.py
@@ -6,8 +6,11 @@ from sqlglot.tokens import Tokenizer, TokenType, Token
 
 
 global schema_name
+schema_name = None
 
 def _parse_foreign_key_index(self:generator.Generator, expression: exp.Expression) -> str:
+
+
     if isinstance(expression.parent.parent, exp.Create):
         global schema_name
         foreign_key_expression = expression.find_all(exp.ForeignKey)
@@ -21,7 +24,10 @@ def _parse_foreign_key_index(self:generator.Generator, expression: exp.Expressio
                 index_name = index_name.replace('\"', '')
                 index_foreign_key_sql = f"CREATE INDEX {index_name} ON {tbl_name} ({column_name})"
                 expression.parent.parent.add_foreign_key_index(index_foreign_key_sql)
-                alter_table = f"ALTER TABLE {schema_name}.{tbl_name} ADD {expression}"
+                if schema_name is not "" or schema_name is not None:
+                    alter_table = f"ALTER TABLE {schema_name}.{tbl_name} ADD {expression}"
+                else:
+                    alter_table = f"ALTER TABLE {tbl_name} ADD {expression}"
                 expression.parent.parent.add_foreign_key_constraint(alter_table)
                 if generator.exclude_fk_constraint:
                     return None

--- a/sqlglot/dialects/nuodb.py
+++ b/sqlglot/dialects/nuodb.py
@@ -24,7 +24,7 @@ def _parse_foreign_key_index(self:generator.Generator, expression: exp.Expressio
                 index_name = index_name.replace('\"', '')
                 index_foreign_key_sql = f"CREATE INDEX {index_name} ON {tbl_name} ({column_name})"
                 expression.parent.parent.add_foreign_key_index(index_foreign_key_sql)
-                if schema_name is not "" or schema_name is not None:
+                if schema_name != "" or schema_name is not None:
                     alter_table = f"ALTER TABLE {schema_name}.{tbl_name} ADD {expression}"
                 else:
                     alter_table = f"ALTER TABLE {tbl_name} ADD {expression}"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -991,8 +991,20 @@ class Create(Expression):
         "no_schema_binding": False,
         "begin": False,
         "clone": False,
-        "foreign_key_index": False
+        "foreign_key_index": False,
+        "foreign_key_constraint": False,
     }
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.foreign_key_index = []
+        self.foreign_key_constraint = []
+
+    def add_foreign_key_index(self, index_sql):
+        self.foreign_key_index.append(index_sql)
+
+    def add_foreign_key_constraint(self, comnstraint_sql):
+        self.foreign_key_constraint.append(comnstraint_sql)
+
 
 
 # https://docs.snowflake.com/en/sql-reference/sql/create-clone

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -741,35 +741,19 @@ class Generator:
 
         if need_fk_for_index:
             foreign_key_ind = expression.foreign_key_index
-            if foreign_key_ind:
+            if foreign_key_ind and foreign_key_ind != "":
                 for index_sql in foreign_key_ind:
-                    create_table_exp += ";\n" + index_sql
+                    if index_sql!="":
+                        create_table_exp += ";\n" + index_sql
 
         if exclude_fk_constraint is True:
             alter_fk_constraint = expression.foreign_key_constraint
-            # print("alter_fk_constraint-->", alter_fk_constraint)
             if alter_fk_constraint:
                 for constraint_sql in alter_fk_constraint:
-                    # print("constraint_sql", constraint_sql)
-                    create_table_exp += ";\n" + constraint_sql
+                    if constraint_sql!= "":
+                        create_table_exp += ";\n" + constraint_sql
 
-        # if need_fk_for_index:
-        #     foreign_key_ind = expression.foreign_key_index
-        #     if foreign_key_ind:
-        #         foreign_exp = ";\n".join(foreign_key_ind)
-        #         create_table_exp += ";\n" + foreign_exp
 
-        # if exclude_fk_constraint is True:
-        #     alter_fk_constraint = expression.foreign_key_constraint
-        #     print("alter_fk_constraint", alter_fk_constraint)
-        #     if alter_fk_constraint:
-        #         alter_table_exp = ";\n".join(alter_fk_constraint)
-        #         create_table_exp += ";\n" + alter_table_exp
-
-        # if exclude_fk_constraint is True:
-        #     if expression.args.get("foreign_key_constraint"):
-        #         alter_table_fk_constraint = expression.args.get("foreign_key_constraint")
-        #         create_table_exp += ";\n" + alter_table_fk_constraint
         return create_table_exp
 
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3486,6 +3486,8 @@ class Parser(metaclass=_Parser):
                     action = "NO ACTION"
                 elif self._match_text_seq("CASCADE"):
                     action = "CASCADE"
+                elif self._match_text_seq("RESTRICT"):
+                    action = "CASCADE"
                 elif self._match_pair(TokenType.SET, TokenType.NULL):
                     action = "SET NULL"
                 elif self._match_pair(TokenType.SET, TokenType.DEFAULT):
@@ -3506,7 +3508,6 @@ class Parser(metaclass=_Parser):
                 options.append("MATCH FULL")
             else:
                 break
-
         return options
 
     def _parse_references(self, match: bool = True) -> t.Optional[exp.Reference]:
@@ -3526,7 +3527,6 @@ class Parser(metaclass=_Parser):
         expressions = self._parse_wrapped_id_vars()
         reference = self._parse_references()
         options = {}
-
         while self._match(TokenType.ON):
             if not self._match_set((TokenType.DELETE, TokenType.UPDATE)):
                 self.raise_error("Expected DELETE or UPDATE")
@@ -3548,8 +3548,6 @@ class Parser(metaclass=_Parser):
             exp.ForeignKey, expressions=expressions, reference=reference, **options  # type: ignore
         )
 
-    # def _parse_foreign_key_index(self) -> exp.ForeignKeyIndex:
-    #     print("parse in parser")
     def _parse_primary_key(
         self, wrapped_optional: bool = False, in_props: bool = False
     ) -> exp.PrimaryKeyColumnConstraint | exp.PrimaryKey:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3544,16 +3544,6 @@ class Parser(metaclass=_Parser):
 
             options[kind] = action
 
-        # index_name = f"{reference}_FK_index"  # Modify this to your naming convention
-        # index_foreign_key_sql = f"CREATE INDEX"
-        # print("index sql-->", index_foreign_key_sql)
-        # foreign_key_exp = self.expression(
-        #     exp.ForeignKey, expressions=expressions, reference=reference, **options  # type: ignore
-        # )
-        # index_exp = self.expression(exp.ForeignKeyIndex, expressions = [index_foreign_key_sql], this = True)
-
-        # foreign_key_exp.set("index", index_foreign_key_sql)
-        # return foreign_key_exp
         return self.expression(
             exp.ForeignKey, expressions=expressions, reference=reference, **options  # type: ignore
         )


### PR DESCRIPTION
The issue at hand arises from MySQL's current behavior of dumping tables in random order, regardless of the parent-child relationships between them. This disregard for table dependencies leads to "table not found" errors, making it difficult to restore databases reliably. To address this issue, we need to modify the MySQL dump process to preserve the order of parent and child tables, ensuring that dependencies are maintained during restoration.
For this fix, I have added a CLI arg. foreign_key_constraint, to exclude/include the constraint part in the CREATE TABLE statement
