### PR TITLE
Added support for computed column

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1273,6 +1273,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
         "minvalue": False,
         "maxvalue": False,
         "cycle": False,
+        "stored": False
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -618,7 +618,8 @@ class Generator:
         maxvalue = f" MAXVALUE {maxvalue}" if maxvalue else ""
         cycle = expression.args.get("cycle")
         cycle_sql = ""
-
+        stored = ""
+        stored =expression.args.get("stored")
         if cycle is not None:
             cycle_sql = f"{' NO' if not cycle else ''} CYCLE"
             cycle_sql = cycle_sql.strip() if not start and not increment else cycle_sql
@@ -631,7 +632,7 @@ class Generator:
         expr = self.sql(expression, "expression")
         expr = f"({expr})" if expr else "IDENTITY"
 
-        return f"GENERATED{this}AS {expr}{sequence_opts}"
+        return f"GENERATED{this}AS {expr}{sequence_opts} {stored}"
 
     def notnullcolumnconstraint_sql(self, expression: exp.NotNullColumnConstraint) -> str:
         return f"{'' if expression.args.get('allow_null') else 'NOT '}NULL"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3409,6 +3409,9 @@ class Parser(metaclass=_Parser):
 
             self._match_r_paren()
 
+        storage = self._parse_bitwise()
+        if storage:
+            this.set("stored", storage)
         return this
 
     def _parse_inline(self) -> exp.InlineLengthColumnConstraint:


### PR DESCRIPTION
- Added support for computed column
- NuoDB doesnt recognize RESTRICT referential integrity when a foreign key is found. So, it is changed to CASCADE 
- NuoDB doesnt take a list of referential integrity, takes only one in the CREATE TABLE statement