### PR TITLE
Added support for prefix indexes

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -132,6 +132,9 @@ class MySQL(Dialect):
             "MEDIUMTEXT": TokenType.MEDIUMTEXT,
             "TINYTEXT": TokenType.TINYTEXT,
             "MEDIUMINT": TokenType.MEDIUMINT,
+            "POINT" : TokenType.POINT,
+            "INT UNSIGNED": TokenType.INT_UNSIGNED,
+            "SMALLINT UNSIGNED": TokenType.SMALLINT_UNSIGNED,
             "SEPARATOR": TokenType.SEPARATOR,
             "ENUM": TokenType.ENUM,
             "START": TokenType.BEGIN,
@@ -282,6 +285,8 @@ class MySQL(Dialect):
         CONSTRAINT_PARSERS = {
             **parser.Parser.CONSTRAINT_PARSERS,
             "KEY": lambda self: self._parse_key_index(),
+            "SPATIAL KEY": lambda self: self._parse_spatial_key(),
+            "FULLTEXT KEY": lambda self: self._parse_fulltext_key(),
         }
 
         PROFILE_TYPES = {
@@ -413,6 +418,22 @@ class MySQL(Dialect):
               | [LOW_PRIORITY] WRITE
           }
         """
+
+        def _parse_spatial_key(self) -> exp.SpatialKey:
+            self._match(TokenType.SPATIAL_KEY)
+            spatialkey_name = self._parse_id_var()
+            spatial_col_name = self._parse_bitwise()
+
+            return self.expression(exp.SpatialKey, this=True, spatialkeyname=spatialkey_name,spatialcolname=spatial_col_name )
+
+        def _parse_fulltext_key(self) -> exp.FullTextKey:
+            self._match(TokenType.FULLTEXT_KEY)
+            keyname = self._parse_id_var()
+            colname = self._parse_bitwise()
+
+            return self.expression(exp.FullTextKey, this=True,keyname=keyname, colname=colname )
+
+
         def _parse_key_index(self) ->exp.KeyColumnConstraintForIndex:
             self._match(TokenType.KEY)
             desc = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1323,6 +1323,11 @@ class KeyColumnConstraintForIndex(ColumnConstraintKind):
                  "colname":False,
                  "options": False}
 
+class SpatialKey(ColumnConstraintKind):
+    arg_types = {"this": False, "spatialkeyname": False, "spatialcolname": False}
+
+class FullTextKey(ColumnConstraintKind):
+    arg_types = {"this": False, "colname": False, "keyname": False}
 
 class Constraint(Expression):
     arg_types = {"this": True, "expressions": True}
@@ -3342,6 +3347,9 @@ class DataType(Expression):
         DATETIME64 = auto()
         ENUM = auto()
         MEDIUMINT = auto()
+        POINT=auto()
+        INT_UNSIGNED=auto()
+        SMALLINT_UNSIGNED=auto()
         INT4RANGE = auto()
         INT4MULTIRANGE = auto()
         INT8RANGE = auto()

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -539,6 +539,17 @@ class Generator:
         exists_sql = " IF EXISTS" if expression.args.get("exists") else ""
         return f"UNCACHE TABLE{exists_sql} {table}"
 
+    def keycolumnconstraintforindex_sql(self, expression: exp.KeyColumnConstraintForIndex) -> str:
+        exp = expression.args.get("expression")
+        desc = expression.args.get("desc")
+        key_name = expression.args.get("keyname")
+        col_name = expression.args.get("colname")
+        opts= expression.args.get("options")
+        if opts is False:
+            return f"KEY {key_name} {col_name}"
+        else:
+            return f"KEY {key_name} {col_name} {opts}"
+
     def cache_sql(self, expression: exp.Cache) -> str:
         lazy = " LAZY" if expression.args.get("lazy") else ""
         table = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -140,6 +140,9 @@ class Parser(metaclass=_Parser):
         TokenType.MEDIUMTEXT,
         TokenType.LONGTEXT,
         TokenType.TINYBLOB,
+        TokenType.POINT,
+        TokenType.INT_UNSIGNED,
+        TokenType.SMALLINT_UNSIGNED,
         TokenType.MEDIUMBLOB,
         TokenType.LONGBLOB,
         TokenType.BINARY,
@@ -673,7 +676,6 @@ class Parser(metaclass=_Parser):
         ),
         "ENCODE": lambda self: self.expression(exp.EncodeColumnConstraint, this=self._parse_var()),
         "FOREIGN KEY": lambda self: self._parse_foreign_key(),
-        # "FOREIGN KEY": lambda self: self._parse_foreign_key_index(),
         "FORMAT": lambda self: self.expression(
             exp.DateFormatColumnConstraint, this=self._parse_var_or_string()
         ),
@@ -704,7 +706,7 @@ class Parser(metaclass=_Parser):
         "RENAME": lambda self: self._parse_alter_table_rename(),
     }
 
-    SCHEMA_UNNAMED_CONSTRAINTS = {"CHECK", "FOREIGN KEY", "LIKE", "PRIMARY KEY", "UNIQUE", "KEY"}
+    SCHEMA_UNNAMED_CONSTRAINTS = {"CHECK", "FOREIGN KEY", "LIKE", "PRIMARY KEY", "UNIQUE", "KEY", "SPATIAL KEY", "FULLTEXT KEY"}
 
     NO_PAREN_FUNCTION_PARSERS = {
         TokenType.ANY: lambda self: self.expression(exp.Any, this=self._parse_bitwise()),
@@ -1598,8 +1600,7 @@ class Parser(metaclass=_Parser):
             type="RANGE"
             if self._match_texts("COLUMNS"):
                 type="RANGE COLUMNS"
-                unsuported =  exp.UnsupportedNuodb(this=True, message="Range column partition is not supported", expression=self.expression)
-                self.raise_error(unsuported)
+                self.raise_error("Range column partition is not supported")
 
             if self._match(TokenType.L_PAREN):
                 expr = self._parse_schema() or self._parse_bracket(self._parse_field())

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -330,6 +330,11 @@ class TokenType(AutoName):
     STRUCT = auto()
     TABLE_SAMPLE = auto()
     TEMPORARY = auto()
+    POINT=auto()
+    INT_UNSIGNED=auto()
+    SMALLINT_UNSIGNED=auto()
+    SPATIAL_KEY= auto()
+    FULLTEXT_KEY=auto()
     THROW = auto()
     TO = auto()
     TOP = auto()
@@ -647,6 +652,8 @@ class Tokenizer(metaclass=_Tokenizer):
         "PIVOT": TokenType.PIVOT,
         "PRAGMA": TokenType.PRAGMA,
         "PRIMARY KEY": TokenType.PRIMARY_KEY,
+        "SPATIAL KEY": TokenType.SPATIAL_KEY,
+        "FULLTEXT KEY": TokenType.FULLTEXT_KEY,
         "PROCEDURE": TokenType.PROCEDURE,
         "QUALIFY": TokenType.QUALIFY,
         "RANGE": TokenType.RANGE,


### PR DESCRIPTION
- NuoDB lacks support for index prefixes, so need to enable this feature. The approach involves generating a computed column that incorporates the initial N characters, and then using this newly created column to establish an index.

- Throwing out error if FULLTEXT and SPATIAL keys are found, as it not compatible with NuoDB

- Mapping out datatypes POINT, INT UNSIGNED, SMALLINT UNSIGNED, BIGINT, etc