### PR TITLE
Dump mysql partition commands

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -845,7 +845,7 @@ class Tokenizer(metaclass=_Tokenizer):
         self.size = len(sql)
         try:
             # mysql dumps partition details as conditional commands. The command starts with the same version number always, the below code is used to make it compatible with NuoDB
-            while "!50100" in self.sql:
+            while self.sql.find("!50100") != -1:
                 index_50100 = self.sql.find("/*!50100")
                 if index_50100 != -1:
                     index_close_comment = self.sql.find("*/", index_50100)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -843,8 +843,16 @@ class Tokenizer(metaclass=_Tokenizer):
         self.reset()
         self.sql = sql
         self.size = len(sql)
-
         try:
+            # mysql dumps partition details as conditional commands. The command starts with the same version number always, the below code is used to make it compatible with NuoDB
+            while "!50100" in self.sql:
+                index_50100 = self.sql.find("/*!50100")
+                if index_50100 != -1:
+                    index_close_comment = self.sql.find("*/", index_50100)
+                    if index_close_comment != -1:
+                        sql = self.sql[:index_close_comment] + self.sql[index_close_comment + 2:]
+                        self.sql = sql.replace("/*!50100", "", 1)
+            self.size = len(self.sql)
             self._scan()
         except Exception as e:
             start = max(self._current - 50, 0)


### PR DESCRIPTION
Title: Improve Handling of Conditional commands for PARTITION TABLES.

Description: MySQL dumps the PARTITION TABLES as conditional comments. These conditional comments are often used when dealing with database migration or when writing SQL code that needs to be compatible with different versions of MySQL.
Currently, the code uses a generic replacement to remove the instances of */ in the SQL string if the partition details are found. 
The current approach, if the partition details are found in the dump file, SqlGlot is tokenizing each word and adding it to AST and then transforming according to the target dialect.