### PR TITLE
Sampada/mig 210(set column constraint)

### DIFF
--- a/sqlglot/dialects/nuodb.py
+++ b/sqlglot/dialects/nuodb.py
@@ -512,6 +512,12 @@ class NuoDB(Dialect):
                 expression = expression.copy()
                 expression.set("this", exp.DataType.Type.INT)
                 expression.args["expressions"] = None
+            if expression.is_type("int"):
+                expression = expression.copy()
+                expression.set("this", exp.DataType.Type.INT)
+                expression.args["expressions"] = None
+            if expression.is_type("set"):
+                raise UnsupportedError("SET COLUMN CONSTRAINT is not supported in NuoDB")
 
             return super().datatype_sql(expression)
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -163,6 +163,8 @@ class Generator:
         exp.DataType.Type.SMALLINT_UNSIGNED: "SMALLINT UNSIGNED",
         exp.DataType.Type.TINYINT_UNSIGNED: "TINYINT UNSIGNED",
         exp.DataType.Type.BIGINT_UNSIGNED: "BIGINT UNSIGNED",
+        exp.DataType.Type.SET: "SET",
+
     }
 
     STAR_MAPPING = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -145,6 +145,7 @@ class Parser(metaclass=_Parser):
         TokenType.SMALLINT_UNSIGNED,
         TokenType.BIGINT_UNSIGNED,
         TokenType.TINYINT_UNSIGNED,
+        TokenType.SET,
         TokenType.MEDIUMBLOB,
         TokenType.LONGBLOB,
         TokenType.BINARY,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -845,7 +845,7 @@ class Tokenizer(metaclass=_Tokenizer):
         self.size = len(sql)
         try:
             # mysql dumps partition details as conditional commands. The command starts with the same version number always, the below code is used to make it compatible with NuoDB
-            while "!50100" in self.sql:
+            while self.sql.find("!50100") != -1:
                 index_50100 = self.sql.find("/*!50100")
                 if index_50100 != -1:
                     index_close_comment = self.sql.find("*/", index_50100)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -843,8 +843,16 @@ class Tokenizer(metaclass=_Tokenizer):
         self.reset()
         self.sql = sql
         self.size = len(sql)
-
         try:
+            # mysql dumps partition details as conditional commands. The command starts with the same version number always, the below code is used to make it compatible with NuoDB
+            while "!50100" in self.sql:
+                index_50100 = self.sql.find("/*!50100")
+                if index_50100 != -1:
+                    index_close_comment = self.sql.find("*/", index_50100)
+                    if index_close_comment != -1:
+                        sql = self.sql[:index_close_comment] + self.sql[index_close_comment + 2:]
+                        self.sql = sql.replace("/*!50100", "", 1)
+            self.size = len(self.sql)
             self._scan()
         except Exception as e:
             start = max(self._current - 50, 0)


### PR DESCRIPTION
Mysql and other databases have SET datatype for the column, A SET is a string object that can have zero or more values, each of which must be chosen from a list of permitted values specified when the table is created.
But, NuoDB does not support SET datatype, this PR deals with these types of situations and throws an error in this case asking the user to change the datatype for the specific column